### PR TITLE
Add alignment outputs, default conda env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ PROFILE = #-pg
 OPENMP = #-fopenmp
 
 # Edit the SRA_INCLUDE_PATH to point to the SRA toolkit on your system
-SRA_PATH = SRA
+# SRA_PATH = SRA
+SRA_PATH = ${CONDA_PREFIX}
+# SRA_PATH = ngs-sdk.3.0.1-linux
 
 INC = -I. -I$(SRA_PATH)/include
 

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,8 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - sra-tools>=3
+  - zlib
+  - make


### PR DESCRIPTION
Hi Jason,

Hope you are well.

I've added a few flags for extracting reads of different "categories" i.e. aligned vs not vs partial. I also simplified the iterator to avoid going through the range.  Now

```
Usage for sracat (v. 0.2)
        [-o <output file *prefix*>] (default is stdout)
        [-z] (zlib-based compression of file-based output; default is no compression)
        [--qual] (fastq output)
        [--unaligned-only] (only output unaligned reads)
        [--aligned-only] (only output aligned reads)
        [--fully-aligned-only] (only output fully aligned reads)
        [--partially-aligned-only] (only output partially aligned reads)
        <SRA accession/file 1> ...
```

I added a conda env.yml file which may be too much extraneous for you - happy to remove if you think so. I can get it to compile using that, but have to specify LD_LIBRARY_PATH=$CONDA_PREFIX/lib64 in order to get it to run.

Thoughts? If you are happy maybe a version bump is in order too.
TIA